### PR TITLE
Fix invalid type passed

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -334,7 +334,7 @@ final class Storage implements StorageInterface
         $assignmentsMtime = @filemtime($this->assignmentFile);
         foreach ($assignments as $userId => $roles) {
             foreach ($roles as $role) {
-                $this->assignments[$userId][$role] = new Assignment($userId, $role, $assignmentsMtime);
+                $this->assignments[$userId][$role] = new Assignment((string)$userId, $role, $assignmentsMtime);
             }
         }
     }


### PR DESCRIPTION
`Fatal error: Uncaught TypeError: Argument 1 passed to Yiisoft\Rbac\Assignment::__construct() must be of the type string, int given`

When saving assignments.php, keys of type string '1' are transformed into an integer, and when loading assignments.php throws an error

https://3v4l.org/JXMCa

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 