### PR TITLE
Codestyle fix

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -410,7 +410,7 @@ final class Storage implements StorageInterface
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
 
-        file_put_contents($file, "<?php\nreturn " . VarDumper::create($data)->export() . ";\n", LOCK_EX);
+        file_put_contents($file, "<?php\n\nreturn " . VarDumper::create($data)->export() . ";\n", LOCK_EX);
         $this->invalidateScriptCache($file);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Currently generated files fail style checks, because extra space after <?php tag is needed. This PR fix it
