### PR TITLE
Separate chain calls

### DIFF
--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -211,7 +211,8 @@ final class ItemsStorage extends CommonStorage implements ItemsStorageInterface
         $items = $this->loadFromFile($this->itemFile);
         $itemsMtime = @filemtime($this->itemFile);
         foreach ($items as $name => $item) {
-            $this->items[$name] = $this->getInstanceFromAttributes($item)
+            $this->items[$name] = $this
+                ->getInstanceFromAttributes($item)
                 ->withCreatedAt($itemsMtime)
                 ->withUpdatedAt($itemsMtime);
         }

--- a/tests/AssignmentsStorageTest.php
+++ b/tests/AssignmentsStorageTest.php
@@ -19,7 +19,9 @@ final class AssignmentsStorageTest extends TestCase
     {
         $storage = $this->createStorage();
         $storage->clear();
-        $this->assertCount(0, $this->createStorage()->getAll());
+        $this->assertCount(0, $this
+            ->createStorage()
+            ->getAll());
     }
 
     public function testGetAssignments(): void

--- a/tests/ItemsStorageTest.php
+++ b/tests/ItemsStorageTest.php
@@ -20,7 +20,9 @@ final class ItemsStorageTest extends TestCase
 
     public function testGetAll(): void
     {
-        $items = $this->createStorage()->getAll();
+        $items = $this
+            ->createStorage()
+            ->getAll();
 
         $this->assertCount(10, $items);
         $this->assertEquals(
@@ -54,7 +56,9 @@ final class ItemsStorageTest extends TestCase
     {
         $storage = $this->createStorage();
         $storage->clearRoles();
-        $this->assertCount(6, $this->createStorage()->getAll());
+        $this->assertCount(6, $this
+            ->createStorage()
+            ->getAll());
     }
 
     public function testClearPermissions(): void
@@ -265,7 +269,9 @@ final class ItemsStorageTest extends TestCase
     public function testUpdateItem(): void
     {
         $storage = $this->createStorage();
-        $storage->update('reader', $storage->get('reader')->withName('new reader'));
+        $storage->update('reader', $storage
+            ->get('reader')
+            ->withName('new reader'));
 
         $children = $storage->getChildren('author');
 

--- a/tests/Rbac/ManagerTest.php
+++ b/tests/Rbac/ManagerTest.php
@@ -392,7 +392,9 @@ class ManagerTest extends TestCase
 
     public function testUpdateRoleNameAndRule(): void
     {
-        $role = $this->itemsStorage->getRole('reader')->withName('new reader');
+        $role = $this->itemsStorage
+            ->getRole('reader')
+            ->withName('new reader');
 
         $this->assertNotNull($this->assignmentsStorage->get('reader', 'reader A'));
         $this->assertNull($this->assignmentsStorage->get('new reader', 'reader A'));
@@ -423,7 +425,8 @@ class ManagerTest extends TestCase
 
     public function testUpdatePermission(): void
     {
-        $permission = $this->itemsStorage->getPermission('deletePost')
+        $permission = $this->itemsStorage
+            ->getPermission('deletePost')
             ->withName('newDeletePost');
 
         $this->assertNotNull($this->assignmentsStorage->get('deletePost', 'author B'));
@@ -446,7 +449,8 @@ class ManagerTest extends TestCase
             'The name "createPost" is already used by another role or permission.'
         );
 
-        $permission = $this->itemsStorage->getPermission('updatePost')
+        $permission = $this->itemsStorage
+            ->getPermission('updatePost')
             ->withName('createPost');
 
         $this->manager->updatePermission('updatePost', $permission);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Readability fix  | according to https://github.com/yiisoft/docs/issues/155, chain calls must be put on separate lines.