### PR TITLE
Rename `getAccessTree()` to `getHierarchy()` in `ItemsStorageInterfac…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,3 @@
 | Is bugfix?    | ✔️/❌
 | New feature?  | ✔️/❌
 | Breaks BC?    | ✔️/❌
-| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Enh #52: Handle concurrency when working with storages (@arogachev)
 - Enh #87: Move handling same names during renaming item in `AssignmentsStorage` to base package (@arogachev)
 - Chg #90: Adjust naming for storages' file name (@arogachev)
-- Chg #: Rename `getAccessTree()` to `getHierarchy()` in `ItemsStorageInterface` implementations (@arogachev)
+- Chg #94: Rename `getAccessTree()` to `getHierarchy()` in `ItemsStorageInterface` implementations (@arogachev)
 
 ## 1.0.0 April 08, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Enh #52: Handle concurrency when working with storages (@arogachev)
 - Enh #87: Move handling same names during renaming item in `AssignmentsStorage` to base package (@arogachev)
 - Chg #90: Adjust naming for storages' file name (@arogachev)
+- Chg #: Rename `getAccessTree()` to `getHierarchy()` in `ItemsStorageInterface` implementations (@arogachev)
 
 ## 1.0.0 April 08, 2022
 

--- a/src/ConcurrentItemsStorageDecorator.php
+++ b/src/ConcurrentItemsStorageDecorator.php
@@ -144,11 +144,11 @@ final class ConcurrentItemsStorageDecorator implements ItemsStorageInterface, Fi
         return $this->storage->getParents($name);
     }
 
-    public function getAccessTree(string $name): array
+    public function getHierarchy(string $name): array
     {
         $this->load();
 
-        return $this->storage->getAccessTree($name);
+        return $this->storage->getHierarchy($name);
     }
 
     public function getDirectChildren(string $name): array

--- a/tests/ItemsStorageWithConcurrencyHandledTest.php
+++ b/tests/ItemsStorageWithConcurrencyHandledTest.php
@@ -164,9 +164,9 @@ final class ItemsStorageWithConcurrencyHandledTest extends TestCase
         $this->assertEmpty($this->getEmptyConcurrentItemsStorage()->getParents('posts.view'));
     }
 
-    public function testGetAccessTree(): void
+    public function testGetHierarchy(): void
     {
-        $this->assertEmpty($this->getEmptyConcurrentItemsStorage()->getAccessTree('posts.view'));
+        $this->assertEmpty($this->getEmptyConcurrentItemsStorage()->getHierarchy('posts.view'));
     }
 
     public function testGetDirectChildren(): void

--- a/tests/ItemsStorageWithConcurrencyNotHandledTest.php
+++ b/tests/ItemsStorageWithConcurrencyNotHandledTest.php
@@ -168,9 +168,9 @@ final class ItemsStorageWithConcurrencyNotHandledTest extends TestCase
         $this->assertNotEmpty($this->getEmptyConcurrentItemsStorage()->getParents('posts.view'));
     }
 
-    public function testGetAccessTree(): void
+    public function testGetHierarchy(): void
     {
-        $this->assertNotEmpty($this->getEmptyConcurrentItemsStorage()->getAccessTree('posts.view'));
+        $this->assertNotEmpty($this->getEmptyConcurrentItemsStorage()->getHierarchy('posts.view'));
     }
 
     public function testGetDirectChildren(): void


### PR DESCRIPTION
…e` implementations

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
